### PR TITLE
Improve wheel smoothness

### DIFF
--- a/dobr/index.html
+++ b/dobr/index.html
@@ -31,7 +31,7 @@
         yellow 180deg 270deg,
         blue 270deg 360deg
       );
-      transition: transform 2s ease-out;
+      transition: transform 5s cubic-bezier(0.33, 1, 0.68, 1);
     }
 
     #arrow {
@@ -82,7 +82,7 @@
 
       setTimeout(() => {
         result.textContent = sectors[randomSector].text;
-      }, 2000);
+      }, 5000);
     };
   </script>
 </body>


### PR DESCRIPTION
## Summary
- adjust the wheel CSS transition to be smoother
- show the result after 5 seconds instead of 2

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685d4b51ed048331a3dc89e0b03f0d37