### PR TITLE
Fix wheel arrow alignment

### DIFF
--- a/dobr/index.html
+++ b/dobr/index.html
@@ -41,7 +41,9 @@
       #arrow {
         position: absolute;
         top: -25px;
-        left: calc(50% - 20px);
+        /* center arrow tip with the wheel's center */
+        left: 50%;
+        transform: translateX(-50%);
         width: 0;
         height: 0;
         border-left: 20px solid transparent;


### PR DESCRIPTION
## Summary
- tweak `#arrow` positioning so the arrow tip lines up with the wheel's center using `left: 50%` and `transform: translateX(-50%)`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686235c7ef14833199225c939c355957