### PR TITLE
Add playful style to wheel heading

### DIFF
--- a/dobr/index.html
+++ b/dobr/index.html
@@ -56,9 +56,20 @@
         font-size: 24px;
         font-weight: bold;
       }
-      h1 {
-        margin-bottom: 1.34em;
-      }
+        h1 {
+          display: inline-block;
+          padding: 12px 25px;
+          margin-bottom: 1.34em;
+          font-family: "Comic Sans MS", cursive, sans-serif;
+          font-size: 36px;
+          color: #fff;
+          background: linear-gradient(45deg, #ff4e50, #f9d423);
+          border: 5px dashed #fff;
+          border-radius: 30px;
+          box-shadow: 0 4px 15px rgba(0, 0, 0, 0.3);
+          text-shadow: 2px 2px 2px rgba(0, 0, 0, 0.2);
+          transform: rotate(-1deg);
+        }
     </style>
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -16,6 +16,17 @@
       overflow: hidden;
     }
 
+    h1 {
+      display: inline-block;
+      padding: 10px 20px;
+      margin: 20px auto;
+      border: 4px double #f8cdda;
+      border-radius: 10px;
+      color: #fff;
+      background: linear-gradient(45deg, #1d2b64, #f8cdda);
+      box-shadow: 0 0 10px rgba(255, 255, 255, 0.7);
+    }
+
     @keyframes fall {
       to {
         transform: translateY(110vh);


### PR DESCRIPTION
## Summary
- restyle the 'Колесо продакта' heading with a playful gradient, dashed border and subtle rotation

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6862394c83208331844ecfafdc6429eb